### PR TITLE
Fix component option name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 - 2018-07-2
+### Changed
+- **BREAKING CHANGE:** `SetupComponent` property `Component` is now `component`
+
 ## 0.2.0 - 2018-06-20
 ### Added
 - Refresh function for `elementsToFind`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class CoolReactComponent extends Component {
     }
 }
 
-const { shallow: setup } = SetupComponent({ Component: CoolReactComponent }); // Component to construct
+const { shallow: setup } = SetupComponent({ component: CoolReactComponent }); // Component to construct
 // I could have used mount instead of shallow if needed
 ```
 
@@ -94,7 +94,7 @@ class NameDisplayer extends Component {
     }
 }
 
-const { shallow: setup } = SetupComponent({ Component: NameDisplayer });
+const { shallow: setup } = SetupComponent({ component: NameDisplayer });
 
 setup({
     firstName: 'Mark'
@@ -125,7 +125,7 @@ class CoolReactComponent extends Component {
 }
 
 const { shallow: setup } = SetupComponent({
-    Component: CoolReactComponent,
+    component: CoolReactComponent,
     elementsToFind: [ // the elements that should be found automatically
         {
             name: 'coolParagraph',
@@ -183,7 +183,7 @@ class InputComponent extends Component {
 }
 
 const { shallow: setup } = setupComponent({
-    Component: InputComponent,
+    component: InputComponent,
     elementsToFind: [
       {
         name: 'input',
@@ -222,7 +222,7 @@ class DisplayName extends Component {
 }
 
 const { shallow: setup } = SetupComponent(
-    Component: DisplayName,
+    component: DisplayName,
     defaultProps: { // the default props for the component
         name: 'Kyle'
     }

--- a/src/setupComponent.js
+++ b/src/setupComponent.js
@@ -3,7 +3,7 @@ import { mount, shallow } from "enzyme";
 import { REFRESH_SYMBOL } from "./constants";
 
 const setupComponent = ({
-                          Component,
+                          component: Component,
                           elementsToFind = [],
                           defaultProps = {}
                         }) => {

--- a/src/setupComponent.test.js
+++ b/src/setupComponent.test.js
@@ -60,7 +60,7 @@ describe('setupComponent', () => {
 
     beforeEach(() => {
       ({ shallow } = setupComponent({
-        Component: TestComponent,
+        component: TestComponent,
         defaultProps: {
           coolTitle: 'i am a default prop'
         }
@@ -85,7 +85,7 @@ describe('setupComponent', () => {
 
     beforeEach(() => {
       ({ mount } = setupComponent({
-        Component: ParentComponent,
+        component: ParentComponent,
         defaultProps: {
           title: 'default title',
           data: 'default data'
@@ -111,7 +111,7 @@ describe('setupComponent', () => {
 
     beforeEach(() => {
       ({ shallow } = setupComponent({
-        Component: MultiItems,
+        component: MultiItems,
         elementsToFind: [
           {
             name: 'coolClass',
@@ -130,7 +130,7 @@ describe('setupComponent', () => {
     let shallow;
     beforeEach(() => {
       ({ shallow } = setupComponent({
-        Component: InputComponent,
+        component: InputComponent,
         elementsToFind: [
           {
             name: 'input',


### PR DESCRIPTION
This pull fixes the weird capitalized SetupComponent property `Component` to a regular camelCase of `component`.